### PR TITLE
App using rm -rf that was unspotted so far ... to be reported as error by the linter

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -79,7 +79,7 @@ ynh_setup_source "$final_path"
 cp -a ${final_path}.old/data ${final_path}
 
 # delete temp directory
-rm -Rf ${final_path}.old
+ynh_secure_remove ${final_path}.old
 
 #=================================================
 # NGINX CONFIGURATION


### PR DESCRIPTION
c.f. https://github.com/YunoHost/package_linter/commit/4b513b4cd67275dfc597d30ddbfe1801293ad15a#diff-661c3b5fe67e77caea903b5fdb903b5fb6e8277c912d4a4af94e179ade2910baR1019

This app is using some `rm -rf` or similar command that was unspotted so far ... The app is gonna be capped to level 4 by the CI until this is fixed :/ 