### PR TITLE
add php8.2-curl php8.2-intl to install

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -72,7 +72,7 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "mariadb-server php8.2-mbstring php8.2-mysql php8.2-zip php8.2-gd php8.2-xml mailutils"
+    packages = "mariadb-server php8.2-mbstring php8.2-mysql php8.2-zip php8.2-gd php8.2-xml php8.2-curl php8.2-intl mailutils"
 
     [resources.database]
     type = "mysql"


### PR DESCRIPTION
## Problem

- After successfully testing the upgrade, Webtrees complained that two php extensions were missing

## Solution

- install them

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
